### PR TITLE
Namespace function

### DIFF
--- a/src/helpers/ast/to-reference.js
+++ b/src/helpers/ast/to-reference.js
@@ -1,6 +1,15 @@
+const memberExpressionSplitter = /\./g;
+
 // Helper to transform a JSX identifier into a normal reference.
 export default function toReference(t, node, identifier = false) {
   if (typeof node === "string") {
+    if (memberExpressionSplitter.test(node)) {
+      return node.
+        split(memberExpressionSplitter).
+        map((s) => t.identifier(s)).
+        reduce((obj, prop) => t.memberExpression(obj, prop));
+    }
+
     return t.identifier(node);
   }
   if (t.isJSXIdentifier(node)) {

--- a/src/helpers/attributes-to-attr-calls.js
+++ b/src/helpers/attributes-to-attr-calls.js
@@ -15,7 +15,7 @@ export default function attrsToAttrCalls(t, file, attrs) {
     } else {
       current.push(attr);
       if (current.length === 2) {
-        calls.push(toFunctionCall(t, iDOMMethod("attr"), current));
+        calls.push(toFunctionCall(t, iDOMMethod(file, "attr"), current));
         current = [];
       }
     }

--- a/src/helpers/attributes-to-attr-calls.js
+++ b/src/helpers/attributes-to-attr-calls.js
@@ -1,6 +1,7 @@
 import injectAttr from "./runtime/attr";
 import injectForOwn from "./runtime/for-own";
 import toFunctionCall from "./ast/to-function-call";
+import iDOMMethod from "./idom-method";
 
 // Transforms an attribute array into sequential attr calls.
 export default function attrsToAttrCalls(t, file, attrs) {
@@ -14,7 +15,7 @@ export default function attrsToAttrCalls(t, file, attrs) {
     } else {
       current.push(attr);
       if (current.length === 2) {
-        calls.push(toFunctionCall(t, "attr", current));
+        calls.push(toFunctionCall(t, iDOMMethod("attr"), current));
         current = [];
       }
     }

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -1,6 +1,7 @@
 import cleanText from "./clean-text";
 import toFunctionCall from "./ast/to-function-call";
 import injectRenderArbitrary from "./runtime/render-arbitrary";
+import iDOMMethod from "./idom-method";
 
 // Filters out empty children, and transform JSX expressions
 // into function calls.
@@ -25,7 +26,7 @@ export default function buildChildren(t, scope, file, children, eager) {
       }
 
       if (type === "string" || type === "number") {
-        child = toFunctionCall(t, "text", [t.literal(value)]);
+        child = toFunctionCall(t, iDOMMethod("text"), [t.literal(value)]);
       }
     } else if (wasInExpressionContainer && !child._iDOMwasJSX) {
       renderArbitraryRef = renderArbitraryRef || injectRenderArbitrary(t, file);

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -26,7 +26,7 @@ export default function buildChildren(t, scope, file, children, eager) {
       }
 
       if (type === "string" || type === "number") {
-        child = toFunctionCall(t, iDOMMethod("text"), [t.literal(value)]);
+        child = toFunctionCall(t, iDOMMethod(file, "text"), [t.literal(value)]);
       }
     } else if (wasInExpressionContainer && !child._iDOMwasJSX) {
       renderArbitraryRef = renderArbitraryRef || injectRenderArbitrary(t, file);

--- a/src/helpers/get.js
+++ b/src/helpers/get.js
@@ -1,0 +1,10 @@
+// Deep retrieves from an object
+export default function get(object, path) {
+  let i;
+  for (i = 0; i < path.length; i++) {
+    if (!object) { break; }
+    object = object[path[i]];
+  }
+
+  return (i === path.length) ? object : undefined;
+}

--- a/src/helpers/idom-method.js
+++ b/src/helpers/idom-method.js
@@ -1,9 +1,7 @@
-let prefix = process.env.IDOM_PREFIX || '';
+let prefix;
 
-export function setPrefix(options = {}) {
-  if (options && 'prefix' in options) {
-    prefix = options.prefix;
-  }
+export function setPrefix(options) {
+  prefix = (options && 'prefix' in options) ? options.prefix : '';
 };
 
 export default function iDOMMethod(method) {

--- a/src/helpers/idom-method.js
+++ b/src/helpers/idom-method.js
@@ -1,0 +1,11 @@
+let prefix = process.env.IDOM_PREFIX || '';
+
+export function setPrefix(options = {}) {
+  if (options && 'prefix' in options) {
+    prefix = options.prefix;
+  }
+};
+
+export default function iDOMMethod(method) {
+  return prefix ? `${prefix}.${method}` : method;
+};

--- a/src/helpers/idom-method.js
+++ b/src/helpers/idom-method.js
@@ -1,9 +1,6 @@
-let prefix;
+import get from "./get";
 
-export function setPrefix(options) {
-  prefix = (options && 'prefix' in options) ? options.prefix : '';
-};
-
-export default function iDOMMethod(method) {
+export default function iDOMMethod(file, method) {
+  const prefix = get(file, ["opts", "extra", "incremental-dom", "prefix"]) || "";
   return prefix ? `${prefix}.${method}` : method;
-};
+}

--- a/src/helpers/inject.js
+++ b/src/helpers/inject.js
@@ -44,7 +44,7 @@ export default function inject(t, file, helper, helperAstFn, dependencyInjectors
     dependencyRefs[dependency] = dependencyRef;
   }
 
-  file.path.unshiftContainer("body", helperAstFn(t, helperRef, dependencyRefs));
+  file.path.unshiftContainer("body", helperAstFn(t, file, helperRef, dependencyRefs));
 
   return helperRef;
 }

--- a/src/helpers/runtime/attr.js
+++ b/src/helpers/runtime/attr.js
@@ -1,5 +1,6 @@
 import inject from "../inject";
 import toFunctionCallStatement from "../ast/to-function-call-statement";
+import iDOMMethod from "../idom-method";
 
 // Flip flops the arguments when calling iDOM's
 // `attr`, so that this function may be used
@@ -17,7 +18,7 @@ function attrAST(t, ref) {
     ref,
     [value, name],
     t.blockStatement([
-      toFunctionCallStatement(t, "attr", [name, value])
+      toFunctionCallStatement(t, iDOMMethod("attr"), [name, value])
     ])
   );
 }

--- a/src/helpers/runtime/attr.js
+++ b/src/helpers/runtime/attr.js
@@ -5,7 +5,7 @@ import iDOMMethod from "../idom-method";
 // Flip flops the arguments when calling iDOM's
 // `attr`, so that this function may be used
 // as an iterator like an Object#forEach.
-function attrAST(t, ref) {
+function attrAST(t, file, ref) {
   const name = t.identifier("name");
   const value = t.identifier("value");
 
@@ -18,7 +18,7 @@ function attrAST(t, ref) {
     ref,
     [value, name],
     t.blockStatement([
-      toFunctionCallStatement(t, iDOMMethod("attr"), [name, value])
+      toFunctionCallStatement(t, iDOMMethod(file, "attr"), [name, value])
     ])
   );
 }

--- a/src/helpers/runtime/for-own.js
+++ b/src/helpers/runtime/for-own.js
@@ -6,7 +6,7 @@ import toFunctionCallStatement from "../ast/to-function-call-statement";
 // the specified iterator function with
 // value and prop name.
 // Depends on the _hasOwn helper.
-function forOwnAST(t, ref, deps) {
+function forOwnAST(t, file, ref, deps) {
   const hasOwn = deps.hasOwn;
   const object = t.identifier("object");
   const iterator = t.identifier("iterator");

--- a/src/helpers/runtime/has-own.js
+++ b/src/helpers/runtime/has-own.js
@@ -1,7 +1,7 @@
 import inject from "../inject";
 
 // Caches a reference to Object#hasOwnProperty.
-function hasOwnAST(t, ref) {
+function hasOwnAST(t, file, ref) {
   /**
    * var _hasOwn = Object.prototype.hasOwnProperty;
    */

--- a/src/helpers/runtime/jsx-wrapper.js
+++ b/src/helpers/runtime/jsx-wrapper.js
@@ -4,7 +4,7 @@ import inject from "../inject";
 // the specified iterator function with
 // value and prop name.
 // Depends on the _hasOwn helper.
-function jsxWrapperAST(t, ref) {
+function jsxWrapperAST(t, file, ref) {
   const func = t.identifier("func");
   const jsxProp = t.memberExpression(
     func,

--- a/src/helpers/runtime/render-arbitrary.js
+++ b/src/helpers/runtime/render-arbitrary.js
@@ -1,6 +1,7 @@
 import inject from "../inject";
 import injectForOwn from "./for-own";
 import toFunctionCallStatement from "../ast/to-function-call-statement";
+import iDOMMethod from "../idom-method";
 
 // Isolated AST code to determine if a value is textual
 // (strings and numbers).
@@ -86,7 +87,7 @@ function renderArbitraryAST(t, ref, deps) {
       t.IfStatement(
         isTextual(t, type, child),
         t.blockStatement([
-          toFunctionCallStatement(t, "text", [child])
+          toFunctionCallStatement(t, iDOMMethod("text"), [child])
         ]),
         t.ifStatement(
           isDOMWrapper(t, type, child),

--- a/src/helpers/runtime/render-arbitrary.js
+++ b/src/helpers/runtime/render-arbitrary.js
@@ -51,7 +51,7 @@ function isArray(t, value) {
 // It may also be an Array or Object, which will be iterated
 // recursively.
 // Depends on the _forOwn helper.
-function renderArbitraryAST(t, ref, deps) {
+function renderArbitraryAST(t, file, ref, deps) {
   const forOwn = deps.forOwn;
   const child = t.identifier("child");
   const type = t.identifier("type");
@@ -87,7 +87,7 @@ function renderArbitraryAST(t, ref, deps) {
       t.IfStatement(
         isTextual(t, type, child),
         t.blockStatement([
-          toFunctionCallStatement(t, iDOMMethod("text"), [child])
+          toFunctionCallStatement(t, iDOMMethod(file, "text"), [child])
         ]),
         t.ifStatement(
           isDOMWrapper(t, type, child),

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import toFunctionCall from "./helpers/ast/to-function-call";
 import toReference from "./helpers/ast/to-reference";
+import iDOMMethod from "./helpers/idom-method";
 
 import attrsToAttrCalls from "./helpers/attributes-to-attr-calls";
 import buildChildren from "./helpers/build-children";
@@ -197,12 +198,12 @@ export default function ({ Plugin, types: t }) {
           const attrCalls = attrsToAttrCalls(t, file, attrs);
 
           const expressions = [
-            toFunctionCall(t, "elementOpenStart", args),
+            toFunctionCall(t, iDOMMethod("elementOpenStart"), args),
             ...attrCalls,
-            toFunctionCall(t, "elementOpenEnd", [tag])
+            toFunctionCall(t, iDOMMethod("elementOpenEnd"), [tag])
           ];
           if (node.selfClosing) {
-            expressions.push(toFunctionCall(t, "elementClose", [tag]));
+            expressions.push(toFunctionCall(t, iDOMMethod("elementClose"), [tag]));
           }
 
           return t.sequenceExpression(expressions);
@@ -221,13 +222,13 @@ export default function ({ Plugin, types: t }) {
           args.push(...attrs);
         }
 
-        return toFunctionCall(t, elementFunction, args);
+        return toFunctionCall(t, iDOMMethod(elementFunction), args);
       }
     },
 
     JSXClosingElement: {
       exit(node) {
-        return toFunctionCall(t, "elementClose", [toReference(t, node.name)]);
+        return toFunctionCall(t, iDOMMethod("elementClose"), [toReference(t, node.name)]);
       }
     },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,11 @@
 import toFunctionCall from "./helpers/ast/to-function-call";
 import toReference from "./helpers/ast/to-reference";
-import iDOMMethod from "./helpers/idom-method";
+import {
+  setPrefix,
+  default as iDOMMethod
+}from "./helpers/idom-method";
 
+import get from "./helpers/get";
 import attrsToAttrCalls from "./helpers/attributes-to-attr-calls";
 import buildChildren from "./helpers/build-children";
 import extractOpenArguments from "./helpers/extract-open-arguments";
@@ -15,7 +19,11 @@ import injectJSXWrapper from "./helpers/runtime/jsx-wrapper";
 
 export default function ({ Plugin, types: t }) {
   return new Plugin("incremental-dom", { visitor : {
-    Program: setupInjector,
+    Program: function(program, parent, scope, file) {
+      const options = get(file, ['opts', 'extra', 'incremental-dom']);
+      setPrefix(options);
+      setupInjector(program, parent, scope, file);
+    },
 
     JSXElement: {
       enter() {

--- a/test/fixtures/prefix/actual.js
+++ b/test/fixtures/prefix/actual.js
@@ -1,0 +1,8 @@
+return <div>
+  <div {...props}></div>
+  <div {...props} />
+  <div></div>
+  <div>{"value"}</div>
+  <div>{3}</div>
+  <div>{value}</div>
+</div>;

--- a/test/fixtures/prefix/expected.js
+++ b/test/fixtures/prefix/expected.js
@@ -1,0 +1,50 @@
+function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || (type === "string" || child && child instanceof String)) {
+    IncrementalDOM.text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else {
+    _forOwn(child, _renderArbitrary);
+  }
+}
+
+function _attr(value, name) {
+  IncrementalDOM.attr(name, value);
+}
+
+function _forOwn(object, iterator) {
+  for (var prop in object) if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+}
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+IncrementalDOM.elementOpen("div");
+IncrementalDOM.elementOpenStart("div");
+
+_forOwn(props, _attr);
+
+IncrementalDOM.elementOpenEnd("div");
+IncrementalDOM.elementClose("div");
+IncrementalDOM.elementOpenStart("div");
+
+_forOwn(props, _attr);
+
+IncrementalDOM.elementOpenEnd("div");
+IncrementalDOM.elementClose("div");
+IncrementalDOM.elementOpen("div");
+IncrementalDOM.elementClose("div");
+IncrementalDOM.elementOpen("div");
+IncrementalDOM.text("value");
+IncrementalDOM.elementClose("div");
+IncrementalDOM.elementOpen("div");
+IncrementalDOM.text(3);
+IncrementalDOM.elementClose("div");
+IncrementalDOM.elementOpen("div");
+
+_renderArbitrary(value);
+
+IncrementalDOM.elementClose("div");
+return IncrementalDOM.elementClose("div");

--- a/test/fixtures/prefix/options.json
+++ b/test/fixtures/prefix/options.json
@@ -1,0 +1,3 @@
+{
+  "prefix": "IncrementalDOM"
+}

--- a/test/fixtures/prefix/options.json
+++ b/test/fixtures/prefix/options.json
@@ -1,3 +1,7 @@
 {
-  "prefix": "IncrementalDOM"
+  "extra": {
+    "incremental-dom": {
+      "prefix": "IncrementalDOM"
+    }
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@ const fs     = require("fs");
 const assert = require("assert");
 const babel  = require("babel");
 const plugin = require("../src/index");
-const setPrefix = require("../src/helpers/idom-method").setPrefix;
 
 function resolve(path) {
   let expected = '';
@@ -17,10 +16,11 @@ function resolve(path) {
   return expected;
 }
 
-function transform(path) {
+function transform(path, extra) {
   return babel.transformFileSync(path, {
     blacklist: ['strict', 'react'],
-    plugins: [plugin]
+    plugins: [plugin],
+    extra: extra
   }).code;
 }
 
@@ -42,15 +42,11 @@ describe("turn jsx into incremental-dom", () => {
       const expected = resolve(path.join(fixtureDir, "expected.js"));
       const opts = parse(resolve(path.join(fixtureDir, "options.json")));
       const throwMsg = opts.throws;
-      const prefix = opts.prefix;
+      const extra = opts.extra;
       let actual;
 
       try {
-        if (prefix) { setPrefix({ prefix }); }
-
-        actual = transform(path.join(fixtureDir, "actual.js"));
-
-        if (prefix) { setPrefix({ prefix: '' }); }
+        actual = transform(path.join(fixtureDir, "actual.js"), extra);
       } catch (err) {
         if (throwMsg) {
           if (err.message.indexOf(throwMsg) >= 0) {


### PR DESCRIPTION
Use a namespace prefix when referencing iDOM methods, i.e. `IncrementalDOM.elementOpen` not `elementOpen`. Passed through the `extra` options under the `incremental-dom` namespace:

```json
{
  "plugins": ["incremental-dom"],
  "blacklist": ["react"],
  "extra": {
    "incremental-dom": {
      "prefix": "IncrementalDOM"
    }
  }
}
```

For the next major, we should default to `IncrementalDOM`.

Closes #18.