### PR TITLE
Hoist Static Attrs

### DIFF
--- a/src/helpers/ast/get-identifier.js
+++ b/src/helpers/ast/get-identifier.js
@@ -1,5 +1,0 @@
-export default function getIdentifier(t, node) {
-  if (t.isLiteral(node)) { return null; }
-  if (t.isIdentifier(node)) { return node; }
-  if (t.isMemberExpression(node)) { return node.object; }
-}

--- a/src/helpers/ast/get-identifier.js
+++ b/src/helpers/ast/get-identifier.js
@@ -1,0 +1,5 @@
+export default function getIdentifier(t, node) {
+  if (t.isLiteral(node)) { return null; }
+  if (t.isIdentifier(node)) { return node; }
+  if (t.isMemberExpression(node)) { return node.object; }
+}

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -5,10 +5,11 @@ import iDOMMethod from "./idom-method";
 
 // Filters out empty children, and transform JSX expressions
 // into function calls.
-export default function buildChildren(t, scope, file, children, eagerDeclarators, { eager }) {
+export default function buildChildren(t, scope, file, children, { eager }) {
   let renderArbitraryRef;
+  const eagerChildren = [];
 
-  return children.reduce((children, child) => {
+  children = children.reduce((children, child) => {
     const wasInExpressionContainer = t.isJSXExpressionContainer(child);
     if (wasInExpressionContainer) {
       child = child.expression;
@@ -33,7 +34,7 @@ export default function buildChildren(t, scope, file, children, eagerDeclarators
 
       if (eager) {
         const ref = scope.generateUidIdentifierBasedOnNode(child);
-        eagerDeclarators.push(t.variableDeclarator(ref, child));
+        eagerChildren.push(t.variableDeclarator(ref, child));
         child = ref;
       }
 
@@ -43,4 +44,6 @@ export default function buildChildren(t, scope, file, children, eagerDeclarators
     children.push(child);
     return children;
   }, []);
+
+  return { children, eagerChildren };
 }

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -18,8 +18,8 @@ export default function buildChildren(t, scope, file, children, { eager }) {
     if (t.isJSXEmptyExpression(child)) { return children; }
 
     if (t.isLiteral(child)) {
-      const type = typeof child.value;
       let value = child.value;
+      const type = typeof value;
 
       if (type === "string") {
         value = cleanText(value);

--- a/src/helpers/eagerly-declare.js
+++ b/src/helpers/eagerly-declare.js
@@ -1,0 +1,15 @@
+// Places all our eager declarators **before** the current path's statement,
+// so that the path or sub-paths may be transformed into a lazily evaluated
+// function.
+export default function eagerlyDeclare(t, scope, path, eagerDeclarators) {
+  // Find the closest statement, and insert our eager declarations
+  // before it.
+  const parentStatement = path.getStatementParent();
+  const declarationPath = parentStatement.insertBefore(t.variableDeclaration(
+    "let",
+    eagerDeclarators
+  ));
+
+  // Add our eager declarations to the scope's tracked bindings.
+  scope.registerBinding("let", declarationPath[0]);
+}

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -37,9 +37,11 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
       value = t.literal(true);
     }
 
+    const literal = t.isLiteral(value);
+
     if (name === "key") {
       statics.push(attr);
-      if (hoist && !(eager || t.isLiteral(value))) {
+      if (hoist && !(eager || literal)) {
         statics.push(t.identifier("undefined"));
         keyIndex = (i << 1) + 1;
       } else {
@@ -50,7 +52,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
       return;
     }
 
-    if (t.isLiteral(value)) {
+    if (literal) {
       statics.push(attr, value);
     } else {
       attrs.push(attr, value);

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -37,8 +37,8 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
     }
 
     if (name === "key") {
-      statics.push(t.literal("key"));
-      if (hoist && !eager) {
+      statics.push(attr);
+      if (hoist && !eager && t.isIdentifier(value)) {
         statics.push(t.identifier("undefined"));
         keyIndex = ((i + 1) << 1) - 1;
       } else {

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -38,14 +38,14 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
 
     if (name === "key") {
       statics.push(t.literal("key"));
-      if (hoist) {
-        if (key) { statics[keyIndex] = key; }
+      if (hoist && !eager) {
         statics.push(t.identifier("undefined"));
+        keyIndex = ((i + 1) << 1) - 1;
       } else {
         statics.push(value);
       }
+
       key = value;
-      keyIndex = ((i + 1) << 1) - 1;
       return;
     }
 

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -39,7 +39,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
 
     if (name === "key") {
       statics.push(attr);
-      if (hoist && !eager && t.isIdentifier(value)) {
+      if (hoist && !(eager || t.isLiteral(value))) {
         statics.push(t.identifier("undefined"));
         keyIndex = (i << 1) + 1;
       } else {

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -40,7 +40,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
       statics.push(attr);
       if (hoist && !eager && t.isIdentifier(value)) {
         statics.push(t.identifier("undefined"));
-        keyIndex = ((i + 1) << 1) - 1;
+        keyIndex = (i << 1) + 1;
       } else {
         statics.push(value);
       }

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -12,6 +12,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
   let key = null;
   let statics = [];
   let keyIndex = -1;
+  let staticAttr = null;
 
   attributes.forEach((attribute, i) => {
     if (t.isJSXSpreadAttribute(attribute)) {
@@ -56,9 +57,24 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
     }
   });
 
-  if (!statics.length) { statics = null; }
   if (!attrs.length) { attrs = null; }
+  if (statics.length) {
+    statics = t.arrayExpression(statics);
+    if (hoist) {
+      const ref = scope.generateUidIdentifier("statics");
+      staticAttr = {
+        declarator: t.variableDeclarator(ref, statics),
+        key: {
+          index: keyIndex,
+          value: key
+        }
+      };
+      statics = ref;
+    }
+  } else {
+    statics = null;
+  }
 
-  return { key, keyIndex, statics, attrs, attributeDeclarators, hasSpread };
+  return { key, keyIndex, statics, attrs, attributeDeclarators, staticAttr, hasSpread };
 }
 

--- a/src/helpers/get-option.js
+++ b/src/helpers/get-option.js
@@ -1,5 +1,5 @@
 // Deep retrieves from an object
-export default function get(object, path) {
+function get(object, path) {
   let i;
   for (i = 0; i < path.length; i++) {
     if (!object) { break; }
@@ -7,4 +7,8 @@ export default function get(object, path) {
   }
 
   return (i === path.length) ? object : undefined;
+}
+
+export default function getOption(file, option) {
+  return get(file, ['opts', 'extra', 'incremental-dom', option]);
 }

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,73 +1,34 @@
 import replaceArrow from "./replace-arrow";
-
-function hoist(t, path, binding, hoisted, elements) {
-  const parent = (binding) ? binding.path.parentPath : path.parentPath;
-  if (parent.isArrowFunctionExpression()) {
-    // The key variable is a formal parameter
-    const body = parent.get("body");
-
-    if (path.parentPath === parent) {
-      // If the parameter in the parent function, then we need to place the
-      // assignment into the iDOM element calls that we replace the arrow
-      // function with.
-      elements.unshift(hoisted);
-    } else if (body.isBlockStatement()) {
-      // This one's easy, just push the assignment to the top of the
-      // function.
-      body.unshiftContainer("body", hoisted);
-    } else {
-      // And this one's a pain. We have to replace the entire arrow
-      // function with the assignment and an explicit return for the
-      // implicitly returned expression.
-      replaceArrow(t, parent, [ hoisted, t.returnStatement(body.node) ]);
-    }
-  } else if (parent.isFunction()) {
-    // The key variable is a formal parameter
-    parent.get("body").unshiftContainer("body", hoisted);
-  } else if (binding && binding.constant) {
-    // With a key variable, we should update they key's value
-    // in the statics array whenever the variable is updated.
-    const statement = binding.path.getStatementParent();
-    statement.insertAfter(hoisted);
-  } else {
-    // Some rouge global key variable
-    elements.unshift(hoisted);
-  }
-}
+import eagerlyDeclare from "./eagerly-declare";
 
 export default function hoistStatics(t, scope, path, staticAttrs, elements) {
   staticAttrs.forEach((attrs) => {
     const declarator = attrs.declarator;
     const { value, index } = attrs.key;
-    const declaration = t.variableDeclaration("let", [declarator]);
     const keyVariable = !t.isLiteral(value) && value;
-    const binding = t.isIdentifier(keyVariable) && scope.getBinding(keyVariable.name);
 
     if (keyVariable) {
-      let hoisted;
-
       if (index === -1) {
         // If there's no key index, that means we're eagerly evaluating
         // the key variable. If that's true, we need to eagerly evaluate
         // the declaration, too.
-        hoisted = declaration;
+        eagerlyDeclare(t, scope, path, [declarator]);
       } else {
         // We need to assign the key variable's value to the statics array
         // at `index`.
-        hoisted = t.expressionStatement(t.assignmentExpression(
+        elements.unshift(t.expressionStatement(t.assignmentExpression(
           "=",
           t.memberExpression(declarator.id, t.literal(index), true),
           value
-        ));
+        )))
       }
-
-      hoist(t, path, binding, hoisted, elements);
     }
 
     // If the statics array does not have a key variable (or we're assigning
     // it's value to index), then we know that we can hoist the statics array
     // to the Program scope.
     if (!keyVariable || index > -1) {
+      const declaration = t.variableDeclaration("let", [declarator]);
       const programScope = scope.getProgramParent();
       programScope.path.unshiftContainer("body", declaration);
     }

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -57,6 +57,11 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
         // Some rouge global key variable
         elements.unshift(hoisted);
       }
+
+      // TODO constantViolations
+      if (binding) {
+        console.log(binding.constantViolations);
+      }
     }
 
     // If we're not wrapping the JSX Element, put the statics array into

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,4 +1,3 @@
-import replaceArrow from "./replace-arrow";
 import eagerlyDeclare from "./eagerly-declare";
 
 export default function hoistStatics(t, scope, path, staticAttrs, elements) {

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,5 +1,40 @@
 import replaceArrow from "./replace-arrow";
 
+function hoist(t, path, binding, hoisted, elements) {
+  const parent = (binding) ? binding.path.parentPath : path.parentPath;
+  if (parent.isArrowFunctionExpression()) {
+    // The key variable is a formal parameter
+    const body = parent.get("body");
+
+    if (path.parentPath === parent) {
+      // If the parameter in the parent function, then we need to place the
+      // assignment into the iDOM element calls that we replace the arrow
+      // function with.
+      elements.unshift(hoisted);
+    } else if (body.isBlockStatement()) {
+      // This one's easy, just push the assignment to the top of the
+      // function.
+      body.unshiftContainer("body", hoisted);
+    } else {
+      // And this one's a pain. We have to replace the entire arrow
+      // function with the assignment and an explicit return for the
+      // implicitly returned expression.
+      replaceArrow(t, parent, [ hoisted, t.returnStatement(body.node) ]);
+    }
+  } else if (parent.isFunction()) {
+    // The key variable is a formal parameter
+    parent.get("body").unshiftContainer("body", hoisted);
+  } else if (binding && binding.constant) {
+    // With a key variable, we should update they key's value
+    // in the statics array whenever the variable is updated.
+    const statement = binding.path.getStatementParent();
+    statement.insertAfter(hoisted);
+  } else {
+    // Some rouge global key variable
+    elements.unshift(hoisted);
+  }
+}
+
 export default function hoistStatics(t, scope, path, staticAttrs, elements, { eager }) {
   staticAttrs.forEach((attrs) => {
     const declaration = t.variableDeclaration("let", [attrs.declarator]);
@@ -25,38 +60,7 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
         ));
       }
 
-      const parent = (binding) ? binding.path.parentPath : path.parentPath;
-      if (parent.isArrowFunctionExpression()) {
-        // The key variable is a formal parameter
-        const body = parent.get("body");
-
-        if (path.parentPath === parent) {
-          // If the parameter in the parent function, then we need to place the
-          // assignment into the iDOM element calls that we replace the arrow
-          // function with.
-          elements.unshift(hoisted);
-        } else if (body.isBlockStatement()) {
-          // This one's easy, just push the assignment to the top of the
-          // function.
-          body.unshiftContainer("body", hoisted);
-        } else {
-          // And this one's a pain. We have to replace the entire arrow
-          // function with the assignment and an explicit return for the
-          // implicitly returned expression.
-          replaceArrow(t, parent, [ hoisted, t.returnStatement(body.node) ]);
-        }
-      } else if (parent.isFunction()) {
-        // The key variable is a formal parameter
-        parent.get("body").unshiftContainer("body", hoisted);
-      } else if (binding && binding.constant) {
-        // With a key variable, we should update they key's value
-        // in the statics array whenever the variable is updated.
-        const statement = binding.path.getStatementParent();
-        statement.insertAfter(hoisted);
-      } else {
-        // Some rouge global key variable
-        elements.unshift(hoisted);
-      }
+      hoist(t, path, binding, hoisted, elements);
     }
 
     // If we're not wrapping the JSX Element, put the statics array into
@@ -67,3 +71,5 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
     }
   });
 }
+
+

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -8,7 +8,6 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
     const binding = identifierKey && scope.getBinding(key.value.name);
 
     if (identifierKey) {
-      const parent = (binding) ? binding.path.parentPath : path.parentPath;
       let hoisted;
 
       if (eager) {
@@ -26,6 +25,7 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
         ));
       }
 
+      const parent = (binding) ? binding.path.parentPath : path.parentPath;
       if (parent.isArrowFunctionExpression()) {
         // The key variable is a formal parameter
         const body = parent.get("body");
@@ -48,7 +48,7 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
       } else if (parent.isFunction()) {
         // The key variable is a formal parameter
         parent.get("body").unshiftContainer("body", hoisted);
-      } else if (binding) {
+      } else if (binding && binding.constant) {
         // With a key variable, we should update they key's value
         // in the statics array whenever the variable is updated.
         const statement = binding.path.getStatementParent();
@@ -56,11 +56,6 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements, { ea
       } else {
         // Some rouge global key variable
         elements.unshift(hoisted);
-      }
-
-      // TODO constantViolations
-      if (binding) {
-        console.log(binding.constantViolations);
       }
     }
 

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,5 +1,4 @@
 import replaceArrow from "./replace-arrow";
-import getIdentifier from "./ast/get-identifier";
 
 function hoist(t, path, binding, hoisted, elements) {
   const parent = (binding) ? binding.path.parentPath : path.parentPath;
@@ -41,8 +40,8 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements) {
     const declarator = attrs.declarator;
     const { value, index } = attrs.key;
     const declaration = t.variableDeclaration("let", [declarator]);
-    const keyVariable = getIdentifier(t, value);
-    const binding = keyVariable && scope.getBinding(keyVariable.name);
+    const keyVariable = !t.isLiteral(value) && value;
+    const binding = t.isIdentifier(keyVariable) && scope.getBinding(keyVariable.name);
 
     if (keyVariable) {
       let hoisted;

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,0 +1,69 @@
+import replaceArrow from "./replace-arrow";
+
+export default function hoistStatics(t, scope, path, staticAttrs, elements, { eager }) {
+  staticAttrs.forEach((attrs) => {
+    const declaration = t.variableDeclaration("let", [attrs.declarator]);
+    const key = attrs.key;
+    const identifierKey = t.isIdentifier(key.value);
+    const binding = identifierKey && scope.getBinding(key.value.name);
+
+    if (identifierKey) {
+      const parent = (binding) ? binding.path.parentPath : path.parentPath;
+      let hoisted;
+
+      if (eager) {
+        // If we wrap the JSX Element, that means we'll need to eagerly
+        // evaluate the key variable. So, we can't lift and assign the key
+        // value like normal.
+        hoisted = declaration;
+      } else {
+        // If we're note wrapping, we can assign the key value and hoist
+        // the statics array to the top level program.
+        hoisted = t.expressionStatement(t.assignmentExpression(
+          "=",
+          t.memberExpression(attrs.declarator.id, t.literal(key.index), true),
+          key.value
+        ));
+      }
+
+      if (parent.isArrowFunctionExpression()) {
+        // The key variable is a formal parameter
+        const body = parent.get("body");
+
+        if (path.parentPath === parent) {
+          // If the parameter in the parent function, then we need to place the
+          // assignment into the iDOM element calls that we replace the arrow
+          // function with.
+          elements.unshift(hoisted);
+        } else if (body.isBlockStatement()) {
+          // This one's easy, just push the assignment to the top of the
+          // function.
+          body.unshiftContainer("body", hoisted);
+        } else {
+          // And this one's a pain. We have to replace the entire arrow
+          // function with the assignment and an explicit return for the
+          // implicitly returned expression.
+          replaceArrow(t, parent, [ hoisted, t.returnStatement(body.node) ]);
+        }
+      } else if (parent.isFunction()) {
+        // The key variable is a formal parameter
+        parent.get("body").unshiftContainer("body", hoisted);
+      } else if (binding) {
+        // With a key variable, we should update they key's value
+        // in the statics array whenever the variable is updated.
+        const statement = binding.path.getStatementParent();
+        statement.insertAfter(hoisted);
+      } else {
+        // Some rouge global key variable
+        elements.unshift(hoisted);
+      }
+    }
+
+    // If we're not wrapping the JSX Element, put the statics array into
+    // the top level Program scope.
+    if (!(binding && eager)) {
+      const programScope = scope.getProgramParent();
+      programScope.path.unshiftContainer("body", declaration);
+    }
+  });
+}

--- a/src/helpers/idom-method.js
+++ b/src/helpers/idom-method.js
@@ -1,6 +1,6 @@
-import get from "./get";
+import getOption from "./get-option";
 
 export default function iDOMMethod(file, method) {
-  const prefix = get(file, ["opts", "extra", "incremental-dom", "prefix"]) || "";
+  const prefix = getOption(file, "prefix") || "";
   return prefix ? `${prefix}.${method}` : method;
 }

--- a/src/helpers/replace-arrow.js
+++ b/src/helpers/replace-arrow.js
@@ -1,0 +1,12 @@
+// A stopgap, until babe/babel#2469 is merged
+// Replaces the body of an implicit-return arrow
+// function with a block statement.
+export default function replaceArrow(t, arrowPath, body) {
+  const arrow = arrowPath.node;
+
+  return arrowPath.replaceWith(t.arrowFunctionExpression(
+    arrow.params,
+    body,
+    arrow.async
+  ));
+}

--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,13 @@ export default function ({ Plugin, types: t }) {
         // into normal expressions.
         const openingElement = node.openingElement;
         const closingElement = node.closingElement;
-        const children = buildChildren(t, scope, file, node.children, eagerDeclarators, { eager });
+
+        const {
+          children,
+          eagerChildren
+        } = buildChildren(t, scope, file, node.children, { eager });
+
+        eagerDeclarators.push(...eagerChildren);
 
         let elements = [ openingElement, ...children ];
         if (closingElement) { elements.push(closingElement); }

--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ export default function ({ Plugin, types: t }) {
         // Only eagerly evaluate our attributes if we will be wrapping the element.
         const eager = JSXElement.getData("needsWrapper") || JSXElement.getData("containerNeedsWrapper");
         const eagerDeclarators = JSXElement.getData("eagerDeclarators");
-        const hoist = !eager && getOption(file, "hoist");
+        const hoist = getOption(file, "hoist");
 
         const {
           key,
@@ -237,7 +237,7 @@ export default function ({ Plugin, types: t }) {
         }
         if (statics) {
           let staticsArg = t.arrayExpression(statics);
-          if (hoist) {
+          if (hoist && !(eager && key)) {
             const ref = scope.generateUidIdentifier("statics");
             JSXElement.setData("staticDeclarator", t.variableDeclarator(ref, staticsArg));
             staticsArg = ref;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import flattenExpressions from "./helpers/flatten-expressions";
 import statementsWithReturnLast from "./helpers/statements-with-return-last";
 import replaceArrow from "./helpers/replace-arrow";
 import hoistStatics from "./helpers/hoist-statics";
+import eagerlyDeclare from "./helpers/eagerly-declare";
 
 import { setupInjector } from "./helpers/inject";
 import injectJSXWrapper from "./helpers/runtime/jsx-wrapper";
@@ -146,15 +147,7 @@ export default function ({ Plugin, types: t }) {
         }
 
         if (!containingJSXElement && eagerDeclarators.length) {
-          // Find the closest statement, and insert our eager declarations
-          // before it.
-          const parentStatement = this.getStatementParent();
-          const [path] = parentStatement.insertBefore(t.variableDeclaration(
-            "let",
-            eagerDeclarators
-          ));
-          // Add our eager declarations to the scopes tracked bindings.
-          scope.registerBinding("let", path);
+          eagerlyDeclare(t, scope, this, eagerDeclarators);
         }
 
         if (!containingJSXElement && staticAttrs.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -241,16 +241,19 @@ export default function ({ Plugin, types: t }) {
 
         const {
           key,
-          keyIndex,
           statics,
           attrs,
           attributeDeclarators,
+          staticAttr,
           hasSpread
         } = extractOpenArguments(t, scope, node.attributes, { eager, hoist });
 
         // Push any eager attribute declarators onto the element's list of
         // eager declarations.
         eagerDeclarators.push(...attributeDeclarators);
+        if (staticAttr) {
+          staticAttrs.push(staticAttr);
+        }
 
         // Only push arguments if they're needed
         const args = [tag];
@@ -258,20 +261,7 @@ export default function ({ Plugin, types: t }) {
           args.push(key || t.literal(null));
         }
         if (statics) {
-          let staticsArray = t.arrayExpression(statics);
-          if (hoist) {
-            const ref = scope.generateUidIdentifier("statics");
-            staticAttrs.push({
-              declarator: t.variableDeclarator(ref, staticsArray),
-              key: {
-                index: keyIndex,
-                value: key
-              }
-            });
-            staticsArray = ref;
-          }
-
-          args.push(staticsArray);
+          args.push(statics);
         }
 
         // If there is a spread element, we need to use

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ export default function ({ Plugin, types: t }) {
         }
 
         if (!containingJSXElement && staticAttrs.length) {
-          hoistStatics(t, scope, this, staticAttrs, elements, { eager });
+          hoistStatics(t, scope, this, staticAttrs, elements);
         }
 
         if (needsWrapper) {

--- a/src/index.js
+++ b/src/index.js
@@ -148,7 +148,7 @@ export default function ({ Plugin, types: t }) {
           if (eagerDeclarators.length) {
             // Find the closest statement, and insert our eager declarations
             // before it.
-            const parentStatement = this.findParent((path) => path.isStatement());
+            const parentStatement = this.getStatementParent();
             const [path] = parentStatement.insertBefore(t.variableDeclaration(
               "let",
               eagerDeclarators
@@ -181,13 +181,13 @@ export default function ({ Plugin, types: t }) {
                 ));
               }
 
-              const parent = (binding) ? binding.path.parentPath : this;
+              const parent = (binding) ? binding.path.parentPath : this.parentPath;
               if (parent.isArrowFunctionExpression() && this.parentPath === parent) {
                 elements.unshift(hoisted);
               } else if (parent.isFunction()) {
                 parent.get("body").unshiftContainer("body", hoisted);
               } else if (binding) {
-                const statement = binding.path.findParent((path) => path.isStatement());
+                const statement = binding.path.getStatementParent();
                 statement.insertAfter(hoisted);
               } else {
                 elements.unshift(hoisted);

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -102,3 +102,7 @@ function fn8(key4) {
   var a = <div id="id"><div id="id2" key={key4} /></div>;
   return <root />
 }
+
+function test() {
+  return <div key="test" />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -47,4 +47,23 @@ function fn7(items) {
   return <root />;
 }
 
+function fn7(items) {
+  var els = [];
+  for (var i = 0; i < items.length; i++) {
+    els.push(<div id="id" />);
+  }
+  return els;
+}
 
+function fn7(items) {
+  return items.map((el, i) => {
+    return <div id="id" />;
+  });
+}
+
+function fn7(items) {
+  items = items.map((el, i) => {
+    return <div id="id" />;
+  });
+  return <root />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -16,6 +16,16 @@ function fn3() {
   return <div id="id" other="value" key={key3} />;
 }
 
+function fn3o() {
+  return <div id="id" key={key4} />;
+}
+
+var fn3o = () => {
+  return <div id="id" key={key4} />;
+}
+
+var fn3o = () => <div id="id" key={key4} />;
+
 function fn4(key4) {
   return <div id="id" other="value" another="test" key={key4} />;
 }
@@ -66,4 +76,29 @@ function fn7(items) {
     return <div id="id" />;
   });
   return <root />;
+}
+
+function fn7(items) {
+  var els = [];
+  for (var i = 0; i < items.length; i++) {
+    els.push(<div id="id" key="key"/>);
+  }
+  return els;
+}
+
+function fn8() {
+  return <div id="id"><div id="id2" /></div>;
+}
+
+function fn8() {
+  return <div id="id"><div id="id2" key={key4} /></div>;
+}
+
+function fn8(key4) {
+  return <div id="id"><div id="id2" key={key4} /></div>;
+}
+
+function fn8(key4) {
+  var a = <div id="id"><div id="id2" key={key4} /></div>;
+  return <root />
 }

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -1,0 +1,50 @@
+var key3 = 'test';
+
+function fn() {
+  return <div id="id" />;
+}
+
+function fn1() {
+  return <div id={"id"} />;
+}
+
+function fn2() {
+  return <div id={3} />;
+}
+
+function fn3() {
+  return <div id="id" other="value" key={key3} />;
+}
+
+function fn4(key4) {
+  return <div id="id" other="value" another="test" key={key4} />;
+}
+
+var fn5 = (key5) => {
+  return <div id="id" key={key5} />;
+}
+
+var fn6 = (key6) => <div id="id" key={key6} />;
+
+function fn7(items) {
+  var els = [];
+  for (var i = 0; i < items.length; i++) {
+    els.push(<div id="id" key={i} />);
+  }
+  return els;
+}
+
+function fn7(items) {
+  return items.map((el, i) => {
+    return <div id="id" key={i} />;
+  });
+}
+
+function fn7(items) {
+  items = items.map((el, i) => {
+    return <div id="id" key={i} />;
+  });
+  return <root />;
+}
+
+

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -131,3 +131,16 @@ function test(props) {
   props.key = 1;
   return <div id="id" key={props.key} />;
 }
+
+function test(key) {
+  key = 1;
+  return <div id="id" key={key} />;
+}
+
+function test() {
+  var key = 'test';
+  key = 1;
+  return <div id="id" key={key} />;
+}
+
+var test = (key) =>  (key = 2, <div id="id" key={key} />);

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -109,3 +109,12 @@ function test() {
 
 var test = (key) =>  (1, <div id="id" key={key} />);
 
+var key;
+
+var test = (k) => key = k;
+
+key = 2;
+
+function test() {
+  return <div id="id" key={key} />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -118,3 +118,11 @@ key = 2;
 function test() {
   return <div id="id" key={key} />;
 }
+
+function test() {
+  return <div id="id" key={props.key} />;
+}
+
+function test(props) {
+  return <div id="id" key={props.key} />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -126,3 +126,8 @@ function test() {
 function test(props) {
   return <div id="id" key={props.key} />;
 }
+
+function test(props) {
+  props.key = 1;
+  return <div id="id" key={props.key} />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -106,3 +106,6 @@ function fn8(key4) {
 function test() {
   return <div key="test" />;
 }
+
+var test = (key) =>  (1, <div id="id" key={key} />);
+

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,4 @@
+var _statics26 = ["key", "test"];
 var _statics24 = ["id", "id"];
 var _statics23 = ["id", "id2", "key", undefined];
 var _statics22 = ["id", "id"];
@@ -177,4 +178,8 @@ function fn8(key4) {
     return elementClose("div");
   });
   return elementVoid("root");
+}
+
+function test() {
+  return elementVoid("div", "test", _statics26);
 }

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,5 @@
+var _statics30 = ["id", "id", "key", undefined];
+var _statics29 = ["id", "id", "key", undefined];
 var _statics28 = ["id", "id", "key", undefined];
 var _statics27 = ["id", "id", "key", undefined];
 var _statics26 = ["key", "test"];
@@ -202,4 +204,14 @@ key = 2;
 function test() {
   _statics28[3] = key;
   return elementVoid("div", key, _statics28);
+}
+
+function test() {
+  _statics29[3] = props.key;
+  return elementVoid("div", props.key, _statics29);
+}
+
+function test(props) {
+  _statics30[3] = props.key;
+  return elementVoid("div", props.key, _statics30);
 }

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,4 @@
+var _statics27 = ["id", "id", "key", undefined];
 var _statics26 = ["key", "test"];
 var _statics24 = ["id", "id"];
 var _statics23 = ["id", "id2", "key", undefined];
@@ -183,3 +184,8 @@ function fn8(key4) {
 function test() {
   return elementVoid("div", "test", _statics26);
 }
+
+var test = function test(key) {
+  _statics27[3] = key;
+  return (1, elementVoid("div", key, _statics27));
+};

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,16 +1,27 @@
-var _statics11 = ["id", "id"];
-var _statics10 = ["id", "id"];
-var _statics9 = ["id", "id"];
-var _statics8 = ["id", "id", "key", undefined];
+var _statics24 = ["id", "id"];
+var _statics23 = ["id", "id2", "key", undefined];
+var _statics22 = ["id", "id"];
+var _statics21 = ["id", "id2", "key", undefined];
+var _statics20 = ["id", "id"];
+var _statics19 = ["id", "id2"];
+var _statics18 = ["id", "id"];
+var _statics17 = ["id", "id", "key", "key"];
+var _statics16 = ["id", "id"];
+var _statics15 = ["id", "id"];
+var _statics14 = ["id", "id"];
+var _statics12 = ["id", "id", "key", undefined];
 
 function _jsxWrapper(func) {
   func.__jsxDOMWrapper = true;
   return func;
 }
 
+var _statics10 = ["id", "id", "key", undefined];
+var _statics9 = ["id", "id", "key", undefined];
+var _statics8 = ["id", "id", "other", "value", "another", "test", "key", undefined];
 var _statics7 = ["id", "id", "key", undefined];
 var _statics6 = ["id", "id", "key", undefined];
-var _statics5 = ["id", "id", "other", "value", "another", "test", "key", undefined];
+var _statics5 = ["id", "id", "key", undefined];
 var _statics4 = ["id", "id", "other", "value", "key", undefined];
 var _statics3 = ["id", 3];
 var _statics2 = ["id", "id"];
@@ -34,19 +45,34 @@ function fn3() {
   return elementVoid("div", key3, _statics4);
 }
 
-function fn4(key4) {
-  _statics5[7] = key4;
+function fn3o() {
+  _statics5[3] = key4;
   return elementVoid("div", key4, _statics5);
 }
 
+var fn3o = function fn3o() {
+  _statics6[3] = key4;
+  return elementVoid("div", key4, _statics6);
+};
+
+var fn3o = function fn3o() {
+  _statics7[3] = key4;
+  return elementVoid("div", key4, _statics7);
+};
+
+function fn4(key4) {
+  _statics8[7] = key4;
+  return elementVoid("div", key4, _statics8);
+}
+
 var fn5 = function fn5(key5) {
-  _statics6[3] = key5;
-  return elementVoid("div", key5, _statics6);
+  _statics9[3] = key5;
+  return elementVoid("div", key5, _statics9);
 };
 
 var fn6 = function fn6(key6) {
-  _statics7[3] = key6;
-  return elementVoid("div", key6, _statics7);
+  _statics10[3] = key6;
+  return elementVoid("div", key6, _statics10);
 };
 
 function fn7(items) {
@@ -54,9 +80,10 @@ function fn7(items) {
 
   var _loop = function () {
     var _i = i;
+    var _statics11 = ["id", "id", "key", _i];
 
     els.push(_jsxWrapper(function () {
-      return elementVoid("div", _i, ["id", "id", "key", _i]);
+      return elementVoid("div", _i, _statics11);
     }));
   };
 
@@ -68,17 +95,18 @@ function fn7(items) {
 
 function fn7(items) {
   return items.map(function (el, i) {
-    _statics8[3] = i;
-    return elementVoid("div", i, _statics8);
+    _statics12[3] = i;
+    return elementVoid("div", i, _statics12);
   });
 }
 
 function fn7(items) {
   items = items.map(function (el, i) {
     var _i2 = i;
+    var _statics13 = ["id", "id", "key", _i2];
 
     return _jsxWrapper(function () {
-      return elementVoid("div", _i2, ["id", "id", "key", _i2]);
+      return elementVoid("div", _i2, _statics13);
     });
   });
   return elementVoid("root");
@@ -88,7 +116,7 @@ function fn7(items) {
   var els = [];
   for (var i = 0; i < items.length; i++) {
     els.push(_jsxWrapper(function () {
-      return elementVoid("div", null, _statics9);
+      return elementVoid("div", null, _statics14);
     }));
   }
   return els;
@@ -96,15 +124,57 @@ function fn7(items) {
 
 function fn7(items) {
   return items.map(function (el, i) {
-    return elementVoid("div", null, _statics10);
+    return elementVoid("div", null, _statics15);
   });
 }
 
 function fn7(items) {
   items = items.map(function (el, i) {
     return _jsxWrapper(function () {
-      return elementVoid("div", null, _statics11);
+      return elementVoid("div", null, _statics16);
     });
+  });
+  return elementVoid("root");
+}
+
+function fn7(items) {
+  var els = [];
+  for (var i = 0; i < items.length; i++) {
+    els.push(_jsxWrapper(function () {
+      return elementVoid("div", "key", _statics17);
+    }));
+  }
+  return els;
+}
+
+function fn8() {
+  elementOpen("div", null, _statics18);
+  elementVoid("div", null, _statics19);
+  return elementClose("div");
+}
+
+function fn8() {
+  _statics21[3] = key4;
+  elementOpen("div", null, _statics20);
+  elementVoid("div", key4, _statics21);
+  return elementClose("div");
+}
+
+function fn8(key4) {
+  _statics23[3] = key4;
+  elementOpen("div", null, _statics22);
+  elementVoid("div", key4, _statics23);
+  return elementClose("div");
+}
+
+function fn8(key4) {
+  var _key4 = key4;
+  var _statics25 = ["id", "id2", "key", _key4];
+
+  var a = _jsxWrapper(function () {
+    elementOpen("div", null, _statics24);
+    elementVoid("div", _key4, _statics25);
+    return elementClose("div");
   });
   return elementVoid("root");
 }

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,0 +1,82 @@
+var _statics8 = ["id", "id", "key", undefined];
+
+function _jsxWrapper(func) {
+  func.__jsxDOMWrapper = true;
+  return func;
+}
+
+var _statics7 = ["id", "id", "key", undefined];
+var _statics6 = ["id", "id", "key", undefined];
+var _statics5 = ["id", "id", "other", "value", "another", "test", "key", undefined];
+var _statics4 = ["id", "id", "other", "value", "key", undefined];
+var _statics3 = ["id", 3];
+var _statics2 = ["id", "id"];
+var _statics = ["id", "id"];
+var key3 = 'test';
+
+_statics4[5] = key3;
+function fn() {
+  return elementVoid("div", null, _statics);
+}
+
+function fn1() {
+  return elementVoid("div", null, _statics2);
+}
+
+function fn2() {
+  return elementVoid("div", null, _statics3);
+}
+
+function fn3() {
+  return elementVoid("div", key3, _statics4);
+}
+
+function fn4(key4) {
+  _statics5[7] = key4;
+  return elementVoid("div", key4, _statics5);
+}
+
+var fn5 = function fn5(key5) {
+  _statics6[3] = key5;
+  return elementVoid("div", key5, _statics6);
+};
+
+var fn6 = function fn6(key6) {
+  _statics7[3] = key6;
+  return elementVoid("div", key6, _statics7);
+};
+
+function fn7(items) {
+  var els = [];
+
+  var _loop = function () {
+    var _i = i;
+
+    els.push(_jsxWrapper(function () {
+      return elementVoid("div", _i, ["id", "id", "key", _i]);
+    }));
+  };
+
+  for (var i = 0; i < items.length; i++) {
+    _loop();
+  }
+  return els;
+}
+
+function fn7(items) {
+  return items.map(function (el, i) {
+    _statics8[3] = i;
+    return elementVoid("div", i, _statics8);
+  });
+}
+
+function fn7(items) {
+  items = items.map(function (el, i) {
+    var _i2 = i;
+
+    return _jsxWrapper(function () {
+      return elementVoid("div", _i2, ["id", "id", "key", _i2]);
+    });
+  });
+  return elementVoid("root");
+}

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,7 @@
+var _statics34 = ["id", "id", "key", undefined];
+var _statics33 = ["id", "id", "key", undefined];
+var _statics32 = ["id", "id", "key", undefined];
+var _statics31 = ["id", "id", "key", undefined];
 var _statics30 = ["id", "id", "key", undefined];
 var _statics29 = ["id", "id", "key", undefined];
 var _statics28 = ["id", "id", "key", undefined];
@@ -33,7 +37,6 @@ var _statics2 = ["id", "id"];
 var _statics = ["id", "id"];
 var key3 = 'test';
 
-_statics4[5] = key3;
 function fn() {
   return elementVoid("div", null, _statics);
 }
@@ -47,6 +50,7 @@ function fn2() {
 }
 
 function fn3() {
+  _statics4[5] = key3;
   return elementVoid("div", key3, _statics4);
 }
 
@@ -189,8 +193,7 @@ function test() {
 }
 
 var test = function test(key) {
-  _statics27[3] = key;
-  return (1, elementVoid("div", key, _statics27));
+  return (1, (_statics27[3] = key, elementVoid("div", key, _statics27)));
 };
 
 var key;
@@ -215,3 +218,26 @@ function test(props) {
   _statics30[3] = props.key;
   return elementVoid("div", props.key, _statics30);
 }
+
+function test(props) {
+  props.key = 1;
+  _statics31[3] = props.key;
+  return elementVoid("div", props.key, _statics31);
+}
+
+function test(key) {
+  key = 1;
+  _statics32[3] = key;
+  return elementVoid("div", key, _statics32);
+}
+
+function test() {
+  var key = 'test';
+  key = 1;
+  _statics33[3] = key;
+  return elementVoid("div", key, _statics33);
+}
+
+var test = function test(key) {
+  return (key = 2, (_statics34[3] = key, elementVoid("div", key, _statics34)));
+};

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,6 @@
+var _statics11 = ["id", "id"];
+var _statics10 = ["id", "id"];
+var _statics9 = ["id", "id"];
 var _statics8 = ["id", "id", "key", undefined];
 
 function _jsxWrapper(func) {
@@ -76,6 +79,31 @@ function fn7(items) {
 
     return _jsxWrapper(function () {
       return elementVoid("div", _i2, ["id", "id", "key", _i2]);
+    });
+  });
+  return elementVoid("root");
+}
+
+function fn7(items) {
+  var els = [];
+  for (var i = 0; i < items.length; i++) {
+    els.push(_jsxWrapper(function () {
+      return elementVoid("div", null, _statics9);
+    }));
+  }
+  return els;
+}
+
+function fn7(items) {
+  return items.map(function (el, i) {
+    return elementVoid("div", null, _statics10);
+  });
+}
+
+function fn7(items) {
+  items = items.map(function (el, i) {
+    return _jsxWrapper(function () {
+      return elementVoid("div", null, _statics11);
     });
   });
   return elementVoid("root");

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,3 +1,4 @@
+var _statics28 = ["id", "id", "key", undefined];
 var _statics27 = ["id", "id", "key", undefined];
 var _statics26 = ["key", "test"];
 var _statics24 = ["id", "id"];
@@ -189,3 +190,20 @@ var test = function test(key) {
   _statics27[3] = key;
   return (1, elementVoid("div", key, _statics27));
 };
+
+var key;
+
+_statics28[3] = key;
+var test = function test(k) {
+  var _tmp = key = k;
+  _statics28[3] = key;
+  return _tmp;
+};
+
+key = 2;
+
+_statics28[3] = key;
+
+function test() {
+  return elementVoid("div", key, _statics28);
+}

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -193,17 +193,13 @@ var test = function test(key) {
 
 var key;
 
-_statics28[3] = key;
 var test = function test(k) {
-  var _tmp = key = k;
-  _statics28[3] = key;
-  return _tmp;
+  return key = k;
 };
 
 key = 2;
 
-_statics28[3] = key;
-
 function test() {
+  _statics28[3] = key;
   return elementVoid("div", key, _statics28);
 }

--- a/test/fixtures/statics-hoist/options.json
+++ b/test/fixtures/statics-hoist/options.json
@@ -1,0 +1,7 @@
+{
+  "extra": {
+    "incremental-dom": {
+      "hoist": true
+    }
+  }
+}


### PR DESCRIPTION
Following the [best practices](http://google.github.io/incremental-dom/#rendering-dom/statics-array) of iDOM, we should hoist our statics array as high as we can.

- For purely constant Static attributes (no key, or a literal key), we hoist the statics array to the Program node.
- When a variable key is defined, we hoist the Statics and replace the key's value with `undefined` in the array.
  - Once the "JSX" iDOM calls are run, we will assign the value of the key to the proper index of the array
- When we wrap a JSX element, we hoist the Statics to the scope of the eager attributes.

Implemented as an option for now, until I'm confident we've found the edge cases.