### PR TITLE
Hoist eagerly-declared statics with a variable key

### DIFF
--- a/src/helpers/ast/is-literal-or-undefined.js
+++ b/src/helpers/ast/is-literal-or-undefined.js
@@ -1,0 +1,5 @@
+// Literals and `undefined` are treated as constant values in attributes and
+// children.
+export default function isLiteralOrUndefined(t, node) {
+  return t.isLiteral(node) || (t.isIdentifier(node) && node.name === "undefined");
+}

--- a/src/helpers/build-children.js
+++ b/src/helpers/build-children.js
@@ -2,6 +2,7 @@ import cleanText from "./clean-text";
 import toFunctionCall from "./ast/to-function-call";
 import injectRenderArbitrary from "./runtime/render-arbitrary";
 import iDOMMethod from "./idom-method";
+import isLiteralOrUndefined from "./ast/is-literal-or-undefined";
 
 // Filters out empty children, and transform JSX expressions
 // into function calls.
@@ -17,7 +18,7 @@ export default function buildChildren(t, scope, file, children, { eager }) {
 
     if (t.isJSXEmptyExpression(child)) { return children; }
 
-    if (t.isLiteral(child)) {
+    if (isLiteralOrUndefined(t, child)) {
       let value = child.value;
       const type = typeof value;
 

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -1,4 +1,5 @@
 import toReference from "./ast/to-reference";
+import isLiteralOrUndefined from "./ast/is-literal-or-undefined";
 
 // Extracts attributes into the appropriate
 // attribute array. Static attributes and the key
@@ -27,7 +28,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
     if (t.isJSXExpressionContainer(value)) {
       value = value.expression;
 
-      if (eager && !t.isLiteral(value) && !value._iDOMwasJSX) {
+      if (eager && !isLiteralOrUndefined(t, value) && !value._iDOMwasJSX) {
         const ref = scope.generateUidIdentifierBasedOnNode(value);
         attributeDeclarators.push(t.variableDeclarator(ref, value));
         value = ref;
@@ -36,7 +37,7 @@ export default function extractOpenArguments(t, scope, attributes, { eager, hois
       value = t.literal(true);
     }
 
-    const literal = t.isLiteral(value);
+    const literal = isLiteralOrUndefined(t, value);
 
     if (name === "key") {
       statics.push(attr);

--- a/src/helpers/extract-open-arguments.js
+++ b/src/helpers/extract-open-arguments.js
@@ -1,5 +1,4 @@
 import toReference from "./ast/to-reference";
-import getOption from "./get-option";
 
 // Extracts attributes into the appropriate
 // attribute array. Static attributes and the key

--- a/src/helpers/get-option.js
+++ b/src/helpers/get-option.js
@@ -10,5 +10,5 @@ function get(object, path) {
 }
 
 export default function getOption(file, option) {
-  return get(file, ['opts', 'extra', 'incremental-dom', option]);
+  return get(file, ["opts", "extra", "incremental-dom", option]);
 }

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -19,7 +19,7 @@ export default function hoistStatics(t, scope, path, staticAttrs, elements) {
           "=",
           t.memberExpression(declarator.id, t.literal(index), true),
           value
-        )))
+        )));
       }
     }
 

--- a/src/helpers/hoist-statics.js
+++ b/src/helpers/hoist-statics.js
@@ -1,10 +1,11 @@
 import eagerlyDeclare from "./eagerly-declare";
+import isLiteralOrUndefined from "./ast/is-literal-or-undefined";
 
 export default function hoistStatics(t, scope, path, staticAttrs, elements) {
   staticAttrs.forEach((attrs) => {
     const declarator = attrs.declarator;
     const { value, index } = attrs.key;
-    const keyVariable = !t.isLiteral(value) && value;
+    const keyVariable = !isLiteralOrUndefined(t, value) && value;
 
     if (keyVariable) {
       if (index === -1) {

--- a/src/helpers/inject.js
+++ b/src/helpers/inject.js
@@ -8,16 +8,11 @@ function setHelperRef(file, helper, value) {
   return file.get(namespace)[helper] = value;
 }
 
-function nullObject() {
-  return Object.create(null);
-}
-
-
 // Sets up the needed data maps for injecting runtime helpers.
 export function setupInjector(program, parent, scope, file) {
   // A map to store helper variable references
   // for each file
-  file.setDynamic(namespace, nullObject);
+  file.setDynamic(namespace, () => Object.create(null));
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import findOtherJSX from "./helpers/find-other-jsx";
 import flattenExpressions from "./helpers/flatten-expressions";
 import statementsWithReturnLast from "./helpers/statements-with-return-last";
 import replaceArrow from "./helpers/replace-arrow";
-import hoistStatics from "./helpers/hoist-statics";
+import { setupHoists, hoistStatics } from "./helpers/hoist-statics";
 import eagerlyDeclare from "./helpers/eagerly-declare";
 
 import { setupInjector } from "./helpers/inject";
@@ -18,7 +18,13 @@ import injectJSXWrapper from "./helpers/runtime/jsx-wrapper";
 
 export default function ({ Plugin, types: t }) {
   return new Plugin("incremental-dom", { visitor : {
-    Program: setupInjector,
+    Program: {
+      enter: [setupInjector, setupHoists],
+
+      exit(program, parent, scope, file) {
+        hoistStatics(t, file, this);
+      }
+    },
 
     JSXElement: {
       enter(node) {
@@ -86,15 +92,15 @@ export default function ({ Plugin, types: t }) {
         const eagerDeclarators = (containingJSXElement) ?
           containingJSXElement.getData("eagerDeclarators") :
           [];
-        const staticAttrs = (containingJSXElement) ?
-          containingJSXElement.getData("staticAttrs") :
+        const staticAssignments = (containingJSXElement) ?
+          containingJSXElement.getData("staticAssignments") :
           [];
 
         this.setData("containerNeedsWrapper", containerNeedsWrapper);
         this.setData("containingJSXElement", containingJSXElement);
         this.setData("eagerDeclarators", eagerDeclarators);
         this.setData("needsWrapper", needsWrapper);
-        this.setData("staticAttrs", staticAttrs);
+        this.setData("staticAssignments", staticAssignments);
       },
 
       exit(node, parent, scope, file) {
@@ -102,7 +108,7 @@ export default function ({ Plugin, types: t }) {
           containerNeedsWrapper,
           containingJSXElement,
           eagerDeclarators,
-          staticAttrs,
+          staticAssignments,
           needsWrapper,
         } = this.data;
 
@@ -154,8 +160,8 @@ export default function ({ Plugin, types: t }) {
           eagerlyDeclare(t, scope, this, eagerDeclarators);
         }
 
-        if (!containingJSXElement && staticAttrs.length) {
-          hoistStatics(t, scope, this, staticAttrs, elements);
+        if (!containingJSXElement && staticAssignments.length) {
+          elements = [...staticAssignments, ...elements];
         }
 
         if (needsWrapper) {
@@ -192,22 +198,22 @@ export default function ({ Plugin, types: t }) {
         const eager = JSXElement.getData("needsWrapper") || JSXElement.getData("containerNeedsWrapper");
         const eagerDeclarators = JSXElement.getData("eagerDeclarators");
         const hoist = getOption(file, "hoist");
-        const staticAttrs = JSXElement.getData("staticAttrs");
+        const staticAssignments = JSXElement.getData("staticAssignments");
 
         const {
           key,
           statics,
           attrs,
           attributeDeclarators,
-          staticAttr,
+          staticAssignment,
           hasSpread
-        } = extractOpenArguments(t, scope, node.attributes, { eager, hoist });
+        } = extractOpenArguments(t, scope, file, node.attributes, { eager, hoist });
 
         // Push any eager attribute declarators onto the element's list of
         // eager declarations.
         eagerDeclarators.push(...attributeDeclarators);
-        if (staticAttr) {
-          staticAttrs.push(staticAttr);
+        if (staticAssignment) {
+          staticAssignments.push(staticAssignment);
         }
 
         // Only push arguments if they're needed

--- a/src/index.js
+++ b/src/index.js
@@ -104,11 +104,9 @@ export default function ({ Plugin, types: t }) {
           eagerDeclarators,
           staticAttrs,
           needsWrapper,
-          key
         } = this.data;
 
         const eager = needsWrapper || containerNeedsWrapper;
-        const hoist = getOption(file, "hoist");
         const explicitReturn = t.isReturnStatement(parent);
         const implicitReturn = t.isArrowFunctionExpression(parent);
 

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -144,3 +144,7 @@ function test() {
 }
 
 var test = (key) =>  (key = 2, <div id="id" key={key} />);
+
+function fn3o() {
+  return <div id="id" key={""} />;
+}

--- a/test/fixtures/statics-hoist/actual.js
+++ b/test/fixtures/statics-hoist/actual.js
@@ -148,3 +148,9 @@ var test = (key) =>  (key = 2, <div id="id" key={key} />);
 function fn3o() {
   return <div id="id" key={""} />;
 }
+
+function nest() {
+  return <div id="id" key={key}>
+    <div id="id" key={key} />
+  </div>;
+}

--- a/test/fixtures/statics-hoist/expected.js
+++ b/test/fixtures/statics-hoist/expected.js
@@ -1,40 +1,46 @@
-var _statics34 = ["id", "id", "key", undefined];
-var _statics33 = ["id", "id", "key", undefined];
-var _statics32 = ["id", "id", "key", undefined];
-var _statics31 = ["id", "id", "key", undefined];
-var _statics30 = ["id", "id", "key", undefined];
-var _statics29 = ["id", "id", "key", undefined];
-var _statics28 = ["id", "id", "key", undefined];
-var _statics27 = ["id", "id", "key", undefined];
-var _statics26 = ["key", "test"];
-var _statics24 = ["id", "id"];
-var _statics23 = ["id", "id2", "key", undefined];
-var _statics22 = ["id", "id"];
-var _statics21 = ["id", "id2", "key", undefined];
-var _statics20 = ["id", "id"];
-var _statics19 = ["id", "id2"];
-var _statics18 = ["id", "id"];
-var _statics17 = ["id", "id", "key", "key"];
-var _statics16 = ["id", "id"];
-var _statics15 = ["id", "id"];
-var _statics14 = ["id", "id"];
-var _statics12 = ["id", "id", "key", undefined];
+var _statics = ["id", "id"],
+    _statics2 = ["id", "id"],
+    _statics3 = ["id", 3],
+    _statics4 = ["id", "id", "other", "value", "key", ""],
+    _statics5 = ["id", "id", "key", ""],
+    _statics6 = ["id", "id", "key", ""],
+    _statics7 = ["id", "id", "key", ""],
+    _statics8 = ["id", "id", "other", "value", "another", "test", "key", ""],
+    _statics9 = ["id", "id", "key", ""],
+    _statics10 = ["id", "id", "key", ""],
+    _statics11 = ["id", "id"],
+    _statics12 = ["id", "id", "key", ""],
+    _statics13 = ["id", "id"],
+    _statics14 = ["id", "id"],
+    _statics15 = ["id", "id"],
+    _statics16 = ["id", "id"],
+    _statics17 = ["id", "id", "key", "key"],
+    _statics18 = ["id", "id"],
+    _statics19 = ["id", "id2"],
+    _statics20 = ["id", "id"],
+    _statics21 = ["id", "id2", "key", ""],
+    _statics22 = ["id", "id"],
+    _statics23 = ["id", "id2", "key", ""],
+    _statics24 = ["id", "id"],
+    _statics25 = ["id", "id2"],
+    _statics26 = ["key", "test"],
+    _statics27 = ["id", "id", "key", ""],
+    _statics28 = ["id", "id", "key", ""],
+    _statics29 = ["id", "id", "key", ""],
+    _statics30 = ["id", "id", "key", ""],
+    _statics31 = ["id", "id", "key", ""],
+    _statics32 = ["id", "id", "key", ""],
+    _statics33 = ["id", "id", "key", ""],
+    _statics34 = ["id", "id", "key", ""],
+    _statics35 = ["id", "id", "key", ""],
+    _statics36 = ["id", "id", "key", ""],
+    _statics37 = ["id", "id", "key", ""];
 
 function _jsxWrapper(func) {
   func.__jsxDOMWrapper = true;
   return func;
 }
 
-var _statics10 = ["id", "id", "key", undefined];
-var _statics9 = ["id", "id", "key", undefined];
-var _statics8 = ["id", "id", "other", "value", "another", "test", "key", undefined];
-var _statics7 = ["id", "id", "key", undefined];
-var _statics6 = ["id", "id", "key", undefined];
-var _statics5 = ["id", "id", "key", undefined];
-var _statics4 = ["id", "id", "other", "value", "key", undefined];
-var _statics3 = ["id", 3];
-var _statics2 = ["id", "id"];
-var _statics = ["id", "id"];
 var key3 = 'test';
 
 function fn() {
@@ -89,10 +95,9 @@ function fn7(items) {
 
   var _loop = function () {
     var _i = i;
-    var _statics11 = ["id", "id", "key", _i];
 
     els.push(_jsxWrapper(function () {
-      return elementVoid("div", _i, _statics11);
+      return elementVoid("div", _i, _statics11, "key", _i);
     }));
   };
 
@@ -112,10 +117,9 @@ function fn7(items) {
 function fn7(items) {
   items = items.map(function (el, i) {
     var _i2 = i;
-    var _statics13 = ["id", "id", "key", _i2];
 
     return _jsxWrapper(function () {
-      return elementVoid("div", _i2, _statics13);
+      return elementVoid("div", _i2, _statics13, "key", _i2);
     });
   });
   return elementVoid("root");
@@ -178,11 +182,10 @@ function fn8(key4) {
 
 function fn8(key4) {
   var _key4 = key4;
-  var _statics25 = ["id", "id2", "key", _key4];
 
   var a = _jsxWrapper(function () {
     elementOpen("div", null, _statics24);
-    elementVoid("div", _key4, _statics25);
+    elementVoid("div", _key4, _statics25, "key", _key4);
     return elementClose("div");
   });
   return elementVoid("root");
@@ -241,3 +244,15 @@ function test() {
 var test = function test(key) {
   return (key = 2, (_statics34[3] = key, elementVoid("div", key, _statics34)));
 };
+
+function fn3o() {
+  return elementVoid("div", "", _statics35);
+}
+
+function nest() {
+  _statics36[3] = key;
+  _statics37[3] = key;
+  elementOpen("div", key, _statics36);
+  elementVoid("div", key, _statics37);
+  return elementClose("div");
+}


### PR DESCRIPTION
Following the discussions in [google/incremental-dom#150](google/incremental-dom#150), it's best to hoist static attributes even if they are eagerly evaluating and contain a variable key.

To accomplish this, we now push the variable key to the dynamic attributes array.